### PR TITLE
Some changes to build.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ builds/
 downloads/
 src/
 usr/
+.DS_Store

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -150,7 +150,8 @@ run(`find . -name '*.h' -exec cp --parents \{\} ../usr/include/ \;`)
 
 # And then the Calculix package
 cd(src)
-run(`git clone git@github.com:JuliaFEM/CalculiX-cmake.git`)
+#run(`git clone git@github.com:JuliaFEM/CalculiX-cmake.git`)
+run(`git clone https://github.com/JuliaFEM/CalculiX-cmake.git`)
 cd(build_calculix)
 run(`cmake ../../src/CalculiX-cmake`)
 run(`make`)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -24,7 +24,8 @@ end
 
 cd(downloads)
 if !isfile(joinpath(downloads,"spooles.2.2.tgz"))
-  run(`wget http://netlib.sandia.gov/linalg/spooles/spooles.2.2.tgz`)
+  #run(`wget http://netlib.sandia.gov/linalg/spooles/spooles.2.2.tgz`)
+  download("http://netlib.sandia.gov/linalg/spooles/spooles.2.2.tgz", "spooles.2.2.tgz")
 end
 cd(spooles)
 run(`tar xzf ../../downloads/spooles.2.2.tgz`)
@@ -91,8 +92,10 @@ end
 # Next ARPACK
 cd(downloads)
 if !isfile(joinpath(downloads,"arpack96.tar.gz"))
-  run(`wget http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz`)
-  run(`wget http://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz`)
+  #run(`wget http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz`)
+  #run(`wget http://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz`)
+  download("http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz", "arpack96.tar.gz")
+  download("http://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz", "patch.tar.gz")
 end
 
 cd(src)


### PR DESCRIPTION
- wget -> download (there's no wget in OS X by default)
- git clone to use https (git@github.com ... is giving public key error)

I think all cp / mv commands should be replaced with julia's internal ones as they should be os independent? I also get errors with copy:

```
cp: illegal option -- -
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file ... target_directory
```

Finally, the compilation is failing using OS X, any ideas?

```
Cloning into 'CalculiX-cmake'...
remote: Counting objects: 658, done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 658 (delta 0), reused 0 (delta 0), pack-reused 655
Receiving objects: 100% (658/658), 1.35 MiB | 575.00 KiB/s, done.
Resolving deltas: 100% (234/234), done.
Checking connectivity... done.
-- The C compiler identification is Clang 5.1.0
-- The Fortran compiler identification is GNU
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working Fortran compiler: /opt/local/bin/gfortran
-- Check for working Fortran compiler: /opt/local/bin/gfortran  -- works
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Checking whether /opt/local/bin/gfortran supports Fortran 90
-- Checking whether /opt/local/bin/gfortran supports Fortran 90 -- yes
CMake Warning (dev) at CMakeLists.txt:6 (LINK_DIRECTORIES):
  This command specifies the relative path

    ../../usr/lib

  as a link directory.

  Policy CMP0015 is not set: link_directories() treats paths relative to the
  source dir.  Run "cmake --help-policy CMP0015" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Try OpenMP C flag = [ ]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Failed
-- Try OpenMP C flag = [-fopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Failed
-- Try OpenMP C flag = [/openmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Failed
-- Try OpenMP C flag = [-Qopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Failed
-- Try OpenMP C flag = [-openmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Failed
-- Try OpenMP C flag = [-xopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Failed
-- Try OpenMP C flag = [+Oopenmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Failed
-- Try OpenMP C flag = [-qsmp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Failed
-- Try OpenMP C flag = [-mp]
-- Performing Test OpenMP_FLAG_DETECTED
-- Performing Test OpenMP_FLAG_DETECTED - Failed
-- Could NOT find OpenMP (missing:  OpenMP_C_FLAGS)
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/jukka/dev/CalculiX.jl/deps/builds/CalculiX
Scanning dependencies of target calculix
[  0%] Building C object CMakeFiles/calculix.dir/src/expand.c.o
In file included from /Users/jukka/dev/CalculiX.jl/deps/src/CalculiX-cmake/src/expand.c:22:
/Users/jukka/dev/CalculiX.jl/deps/src/CalculiX-cmake/src/CalculiX.h:1510:21: error:
      unknown type name 'pthread_t'
int pthread_create (pthread_t *thread_id, const pthread_attr_t *attributes,
                    ^
/Users/jukka/dev/CalculiX.jl/deps/src/CalculiX-cmake/src/CalculiX.h:1513:19: error:
      unknown type name 'pthread_t'
int pthread_join (pthread_t thread, void **status_ptr);
                  ^
In file included from /Users/jukka/dev/CalculiX.jl/deps/src/CalculiX-cmake/src/expand.c:24:
/Users/jukka/dev/CalculiX.jl/deps/src/CalculiX-cmake/src/spooles.h:40:2: error:
      unknown type name 'IV'
        IV *newToOldIV, *oldToNewIV;
        ^
/Users/jukka/dev/CalculiX.jl/deps/src/CalculiX-cmake/src/spooles.h:41:2: error:
      unknown type name 'SolveMap'
        SolveMap *solvemap;
        ^
/Users/jukka/dev/CalculiX.jl/deps/src/CalculiX-cmake/src/spooles.h:42:2: error:
      unknown type name 'FrontMtx'
        FrontMtx *frontmtx;
        ^
/Users/jukka/dev/CalculiX.jl/deps/src/CalculiX-cmake/src/spooles.h:43:2: error:
      unknown type name 'SubMtxManager'
        SubMtxManager *mtxmanager;
        ^
/Users/jukka/dev/CalculiX.jl/deps/src/CalculiX-cmake/src/spooles.h:44:2: error:
      unknown type name 'ETree'
        ETree *frontETree;
        ^
7 errors generated.
make[2]: *** [CMakeFiles/calculix.dir/src/expand.c.o] Error 1
make[1]: *** [CMakeFiles/calculix.dir/all] Error 2
make: *** [all] Error 2
=============================[ ERROR: CalculiX.jl ]=============================

LoadError: failed process: Process(`make`, ProcessExited(2)) [2]
while loading /Users/jukka/.julia/v0.4/CalculiX.jl/deps/build.jl, in expression starting on line 157

================================================================================

================================[ BUILD ERRORS ]================================

WARNING: CalculiX.jl had build errors.

 - packages with build errors remain installed in /Users/jukka/.julia/v0.4
 - build the package(s) and all dependencies with `Pkg.build("CalculiX.jl")`
 - build a single package by running its `deps/build.jl` script

================================================================================
```
